### PR TITLE
Prevent ReadMe / Compiling / Github Config changes from triggering CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,6 +1,14 @@
 name: Build
 
-on: [push, pull_request]
+on:
+  push:
+    paths-ignore:
+      - '**.md'
+      - '**.yml'
+  pull_request:
+    paths-ignore:
+      - '**.md'
+      - '**.yml'
 
 jobs:
   build:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,11 +4,9 @@ on:
   push:
     paths-ignore:
       - '**.md'
-      - '**.yml'
   pull_request:
     paths-ignore:
       - '**.md'
-      - '**.yml'
 
 jobs:
   build:


### PR DESCRIPTION
No need to release a new CI build anytime readme.md, compiling.md, or github config has been changed, especially if forgetting to include `[skip ci]`